### PR TITLE
fix: adjust z-indexes

### DIFF
--- a/src/components/gender/NewCollectionSection.tsx
+++ b/src/components/gender/NewCollectionSection.tsx
@@ -17,7 +17,7 @@ const NewCollectionSection = () => {
   const [isEnd, setIsEnd] = useState(false);
 
   return (
-    <div className="relative mx-auto w-full max-w-custom-1440 pt-[140px]">
+    <div className="relative z-[0] mx-auto w-full max-w-custom-1440 pt-[140px]">
       <SubtitleSection title="Нова колекція" />
       <div className="absolute right-0 top-[166px] mb-20 flex justify-end">
         <SlidePrevButton swiperRef={swiperRef} disabled={isBeginning} />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -14,7 +14,7 @@ const MainLayout: FC = () => {
 
   return (
     <>
-      <div className="fixed left-1/2 z-50 z-[1] w-full -translate-x-1/2 flex-col backdrop-blur">
+      <div className="fixed left-1/2 z-[1] w-full -translate-x-1/2 flex-col backdrop-blur">
         {showBanner && <AnnouncementBar onClose={() => setShowBanner(false)} />}
         <Header />
       </div>


### PR DESCRIPTION
Resolve z-index conflict between Radix Dialog, header, and Swiper by setting z-index: 0 on Swiper wrapper.