### PR TITLE
refactor: remove unnecessary createApis and keep only one

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -12,8 +12,7 @@ import {
 } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
-import { authApi } from '../services/authApi';
-import { notificationApi } from '../services/notificationApi';
+import { api } from '../services/api';
 import { authReducer } from './authSlice';
 import { cartReducer } from './cart/slice';
 import { productReducer } from './products/slice';
@@ -28,9 +27,8 @@ const persistedAuthReducer = persistReducer(authPersistConfig, authReducer);
 
 export const store = configureStore({
   reducer: {
+    [api.reducerPath]: api.reducer,
     auth: persistedAuthReducer,
-    [authApi.reducerPath]: authApi.reducer,
-    [notificationApi.reducerPath]: notificationApi.reducer,
     cart: cartReducer,
     products: productReducer,
   },
@@ -39,7 +37,7 @@ export const store = configureStore({
       serializableCheck: {
         ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
       },
-    }).concat(authApi.middleware, notificationApi.middleware),
+    }).concat(api.middleware),
 });
 
 setupListeners(store.dispatch);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,9 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const API_BASE_URL = 'https://gw-retail.duckdns.org';
+
+export const api = createApi({
+  reducerPath: 'api',
+  baseQuery: fetchBaseQuery({ baseUrl: API_BASE_URL }),
+  endpoints: () => ({}),
+});

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { api } from './api';
 
 export interface LoginRequest {
   email: string;
@@ -35,9 +35,7 @@ export interface ResetPasswordResponse {
   message: string;
 }
 
-export const authApi = createApi({
-  reducerPath: 'authApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://gw-retail.duckdns.org/' }),
+const authApi = api.injectEndpoints({
   endpoints: (builder) => ({
     signIn: builder.mutation<AuthResponse, LoginRequest>({
       query: ({ email, password }) => ({

--- a/src/services/notificationApi.ts
+++ b/src/services/notificationApi.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { api } from './api';
 
 export interface SubscribeRequest {
   email: string;
@@ -12,20 +12,18 @@ export interface SubscriptionResponse {
   message: string;
 }
 
-export const notificationApi = createApi({
-  reducerPath: 'notificationApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://gw-retail.duckdns.org/api/' }),
+export const notificationApi = api.injectEndpoints({
   endpoints: (builder) => ({
     subscribe: builder.mutation<SubscriptionResponse, SubscribeRequest>({
       query: ({ email }) => ({
-        url: 'notification/sub',
+        url: 'api/notification/sub',
         method: 'POST',
         body: { email },
       }),
     }),
     unsubscribe: builder.mutation<SubscriptionResponse, UnsubscribeRequest>({
       query: ({ token }) => ({
-        url: 'notification/unsub',
+        url: 'api/notification/unsub',
         method: 'POST',
         body: { token },
       }),


### PR DESCRIPTION
https://redux-toolkit.js.org/rtk-query/api/createApi

"Typically, you should only have one API slice per base URL that your application needs to communicate with. For example, if your site fetches data from both /api/posts and /api/users, you would have a single API slice with /api/ as the base URL, and separate endpoint definitions for posts and users. This allows you to effectively take advantage of [automated re-fetching](https://redux-toolkit.js.org/rtk-query/usage/automated-refetching) by defining [tag](https://redux-toolkit.js.org/rtk-query/usage/automated-refetching#tags) relationships across endpoints.

This is because:

Automatic tag invalidation only works within a single API slice. If you have multiple API slices, the automatic invalidation won't work across them.
Every createApi call generates its own middleware, and each middleware added to the store will run checks against every dispatched action. That has a perf cost that adds up. So, if you called createApi 10 times and added 10 separate API middleware to the store, that will be noticeably slower perf-wise.
For maintainability purposes, you may wish to split up endpoint definitions across multiple files, while still maintaining a single API slice which includes all of these endpoints. See [code splitting](https://redux-toolkit.js.org/rtk-query/usage/code-splitting) for how you can use the injectEndpoints property to inject API endpoints from other files into a single API slice definition."